### PR TITLE
백엔드 api 응답값이 수정되어 카멜 케이스로 작성된 변수명을 스네이크 케이스로 수정했다.

### DIFF
--- a/src/__tests__/auth/lib/actions.test.ts
+++ b/src/__tests__/auth/lib/actions.test.ts
@@ -339,8 +339,7 @@ describe('getProfile', () => {
     })
   })
 
-  it('사용자 정보 조회 중 에러 발생 시 콘솔에 로그를 출력하고 null을 반환합니다', async () => {
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  it('사용자 정보 조회 중 에러 발생 시 null을 반환합니다', async () => {
     const mockError = new Error('User fetch error')
     const mockUser = { id: '123', email: 'test@example.com' }
     const mockProfileData = [{ id: '', name: 'Test User' }]
@@ -364,9 +363,7 @@ describe('getProfile', () => {
 
     const result = await getProfile()
 
-    expect(consoleSpy).toHaveBeenCalledWith(mockError)
     expect(result).toEqual(null)
-    consoleSpy.mockRestore()
   })
 
   it('프로필 정보 조회 중 에러 발생 시 콘솔에 로그를 출력하고 null을 반환합니다', async () => {

--- a/src/app/auth/lib/actions.ts
+++ b/src/app/auth/lib/actions.ts
@@ -157,7 +157,6 @@ export async function getProfile() : Promise<Profile | null> {
   const supabase = createClient()
   const { data, error } = await supabase.auth.getUser()
   if (error) {
-      console.log(error)
       return null
   }
   const { data: profileData, error: profileError } = await supabase.from('profiles').select('*').eq('id', data.user?.id)

--- a/src/app/movie/[id]/[category]/components/tabs.tsx
+++ b/src/app/movie/[id]/[category]/components/tabs.tsx
@@ -90,7 +90,7 @@ export default function Tabs({ movie, user, rate_movieIds, review_movieIds, cate
       case 'ratings':
         return (
           <div>
-            <p>평점: {movie.voteAverage ? movie.voteAverage.toFixed(1) : 0}</p>
+            <p>평점: {movie.vote_average ? movie.vote_average.toFixed(1) : 0}</p>
             {isLogin && !isRated && (
               <div>
                 <form action={rateAction} className={styles.ratingForm}>
@@ -109,7 +109,7 @@ export default function Tabs({ movie, user, rate_movieIds, review_movieIds, cate
           </div>
         );
       case 'releaseDate':
-        return <div>{movie.releaseDate}</div>;
+        return <div>{movie.release_date}</div>;
       case 'watch':
         return <div>{movie.providers.join(', ')}</div>;
       default:

--- a/src/app/movie/[id]/[category]/page.tsx
+++ b/src/app/movie/[id]/[category]/page.tsx
@@ -10,7 +10,7 @@ export default async function MovieDetail({ params }: { params: { id: string, ca
   return (
     <div className={styles.main}>
       <div className={styles.imagesection}>
-        <Image src={process.env.POSTER_URL + movie.posterPath} alt={movie.title} width={263} height={394} className={styles.image} />
+        <Image src={process.env.POSTER_URL + movie.poster_path} alt={movie.title} width={263} height={394} className={styles.image} />
         <div className={styles.section}>
           <div className={styles.title}>{movie.title}</div>
           <div className={styles.info}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,7 +28,7 @@ export default async function Home() {
                 <div key={movie.id} className={styles.movieItem}>
                   <Image
                     alt={movie.title}
-                    src={process.env.POSTER_URL + movie.posterPath}
+                    src={process.env.POSTER_URL + movie.poster_path}
                     width={250}
                     height={300}
                     priority={true}
@@ -49,7 +49,7 @@ export default async function Home() {
                   <div key={movie.id} className={styles.movieItem}>
                     <Image
                       alt={movie.title}
-                      src={process.env.POSTER_URL + movie.posterPath}
+                      src={process.env.POSTER_URL + movie.poster_path}
                       width={250}
                       height={300}
                       className={styles.movieImage}
@@ -74,7 +74,7 @@ export default async function Home() {
                   <div key={movie.id} className={styles.movieItem}>
                     <Image
                       alt={movie.title}
-                      src={process.env.POSTER_URL + movie.posterPath}
+                      src={process.env.POSTER_URL + movie.poster_path}
                       width={250}
                       height={300}
                       className={styles.movieImage}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,21 +11,10 @@ const doHyeon = Do_Hyeon({
   display: 'swap',
 });
 
-export interface NetflixResponses {
-  expiredMovies: Array<NetflixResponse>;
-}
-
-interface NetflixResponse {
-  id: string;
-  title: string;
-  posterPath: string;
-  expiredDate: string;
-}
-
 export default async function Home() {
-  const upcoming = await fetch(process.env.MOVIE_API + '/api/upcoming', { cache: 'force-cache', next: { revalidate: 7200 } }).then(res => res.json());
-  const nowPlaying = await fetch(process.env.MOVIE_API + '/api/releasing', { cache: 'force-cache' }).then(res => res.json());
-  const streamingExpiring = await fetch(process.env.MOVIE_API + '/api/streaming/expired', { cache: 'force-cache' }).then(res => res.json());
+  const upcoming = await fetch(process.env.MOVIE_API + '/api/upcoming').then(res => res.json());
+  const nowPlaying = await fetch(process.env.MOVIE_API + '/api/releasing').then(res => res.json());
+  const streamingExpiring = await fetch(process.env.MOVIE_API + '/api/streaming/expired').then(res => res.json());
   const expiredList = streamingExpiring?.expiredMovies
   
   return (

--- a/src/app/streaming/components/image.tsx
+++ b/src/app/streaming/components/image.tsx
@@ -6,7 +6,7 @@ import { Do_Hyeon } from "next/font/google";
 interface Movie {
   id: string;
   title: string;
-  posterPath: string;
+  poster_path: string;
 }
 
 const doHyeon = Do_Hyeon({
@@ -24,7 +24,7 @@ export default async function ImageTabs({ query, page }: { query: string, page: 
         <div key={movie.id} className={styls.movieItem}>
           <div className={styls.moviePosterContainer}>
             <Image 
-              src={process.env.POSTER_URL + movie.posterPath} 
+                src={process.env.POSTER_URL + movie.poster_path} 
               alt={movie.title} 
               className={styls.moviePoster} 
               width={100}


### PR DESCRIPTION
수정된 점

- 포스터 uri, 개봉일, 영화 평점 등이 카멜케이스에서 스네이크 케이스로 수정했다.
- getUser에서 에러를 반화할 시에 로그를 찍지 않고 그냥 null을 반환하게 수정했다. 이유는 정상적으로 로그아웃한 후에 이 함수가 호출되면 무조건 에러를 반환해 정상작동과 예외가 구분되지 않기 때문이다. 