### PR TITLE
잡지 기사 페이지를 추가했다.

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,7 +14,7 @@ const nextConfig = {
             },
             {
                 protocol: 'https',
-                hostname: 'www.fangoria.com',
+                hostname: process.env.NEXT_PUBLIC_FAANGORIA_NOTHOST,
                 port: '',
             },
         ],

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,6 +12,11 @@ const nextConfig = {
                 hostname: process.env.NEXT_PUBLIC_SUPABASE_NOTHOST,
                 port: '',
             },
+            {
+                protocol: 'https',
+                hostname: 'www.fangoria.com',
+                port: '',
+            },
         ],
     },
     experimental: {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -52,8 +52,8 @@ export default async function RootLayout({
               <li><Link href="/inDevelopment"><Image src={"/icons/game.svg"} alt="게임" width={30} height={30} className={styles.icon}/>
               <span>게임</span>
               </Link></li>
-                <li><Link href="/inDevelopment"><Image src={"/icons/search.svg"} alt="찾기" width={30} height={30} className={styles.icon}/>
-              <span>찾기</span>
+                <li><Link href="/magazine"><Image src={"/icons/search.svg"} alt="찾기" width={30} height={30} className={styles.icon}/>
+              <span>잡지 기사</span>
               </Link></li>
               {profile && profile.id ? (
                 <ProfileDropdown isMobile={false} profile={profile}/>
@@ -75,6 +75,7 @@ export default async function RootLayout({
             <Link href="/streaming"><Image src={"/icons/video.svg"} alt="스트리밍" width={30} height={30} className={styles.icon}/><span>스트리밍</span></Link>
             <Link href="/inDevelopment"><Image src={"/icons/manga.svg"} alt="만화" width={30} height={30} className={styles.icon}/><span>만화</span></Link>
             <Link href="/inDevelopment"><Image src={"/icons/game.svg"} alt="게임" width={30} height={30} className={styles.icon}/><span>게임</span></Link>
+            <Link href="/magazine"><Image src={"/icons/search.svg"} alt="찾기" width={30} height={30} className={styles.icon}/><span>잡지 기사</span></Link>
             {profile && profile.id ? (
               <ProfileDropdown isMobile={true} profile={profile}/>
             ) : (

--- a/src/app/magazine/page.module.css
+++ b/src/app/magazine/page.module.css
@@ -1,0 +1,59 @@
+.magazine-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.magazine-title {
+  font-size: 3rem;
+  font-weight: bold;
+  margin-bottom: 2rem;
+  text-align: center;
+  color: #ff0000;
+}
+
+.articles-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.article-card {
+  display: flex;
+  border-bottom: 1px solid #e2e8f0;
+  padding-bottom: 2rem;
+}
+
+.article-image {
+  width: 200px;
+  height: 150px;
+  object-fit: cover;
+  margin-right: 1rem;
+}
+
+.article-content {
+  flex: 1;
+}
+
+.article-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: #000;
+}
+
+.article-title:hover {
+  color: #ff0000;
+}
+
+.article-author {
+  color: #4b5563;
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+}
+
+.article-excerpt {
+  color: #4b5563;
+  font-size: 1rem;
+  line-height: 1.5;
+}

--- a/src/app/magazine/page.tsx
+++ b/src/app/magazine/page.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import styles from './page.module.css';
+import localFont from 'next/font/local';
+
+export interface Article {
+  title: string;
+  url: string;
+  imageUrl: string;
+  author?: string;
+  excerpt?: string;
+}
+
+const doHyeon = localFont({
+  src: '../fonts/DoHyeon-Regular.ttf',
+  display: 'swap',
+});
+
+async function fetchArticles(): Promise<Article[]> {
+  try {
+    const response = await fetch('http://localhost:3031/api/fangoria-articles', { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error('기사를 가져오는데 실패했습니다');
+    }
+    return response.json();
+  } catch (error) {
+    console.error('기사를 가져오는 중 오류 발생:', error);
+    return [];
+  }
+}
+
+export default async function MagazinePage() {
+  const articles = await fetchArticles();
+
+  return (
+    <div className={styles['magazine-container']} style={doHyeon.style}>
+      <h1 className={styles['magazine-title']}>Fangoria</h1>
+      <div className={styles['articles-grid']}>
+        {articles.map((article, index) => (
+          <div key={index} className={styles['article-card']}>
+            {article.imageUrl && (
+              <Image
+                src={article.imageUrl}
+                alt={article.title}
+                width={200}
+                height={150}
+                className={styles['article-image']}
+              />
+            )}
+            <div className={styles['article-content']}>
+              <Link href={article.url}>
+                <h2 className={styles['article-title']}>{article.title}</h2>
+              </Link>
+              {article.author && <p className={styles['article-author']}>BY {article.author.toUpperCase()}</p>}
+              {article.excerpt && <p className={styles['article-excerpt']}>{article.excerpt}</p>}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/magazine/page.tsx
+++ b/src/app/magazine/page.tsx
@@ -18,7 +18,7 @@ const doHyeon = localFont({
 
 async function fetchArticles(): Promise<Article[]> {
   try {
-    const response = await fetch('http://localhost:3031/api/fangoria-articles', { cache: 'no-store' });
+    const response = await fetch(`${process.env.NEXT_PUBLIC_MAGAZINE_PROXY}/api/fangoria-articles`, { cache: 'no-store' });
     if (!response.ok) {
       throw new Error('기사를 가져오는데 실패했습니다');
     }


### PR DESCRIPTION
추가된 점

- 프록시 서버에서 잡지 기사 이미지 url, 제목, 저자, 기사 링크를 가져와 렌더링한다.
- 기사 제목을 누르면 원사이트로 이동한다.
