### PR TITLE
fix: PageTabs 초기 렌더링 탭 설정 로직 개선

### DIFF
--- a/src/app/movie/[id]/[category]/components/PageTabs.tsx
+++ b/src/app/movie/[id]/[category]/components/PageTabs.tsx
@@ -20,7 +20,20 @@ interface PageTabsProps {
 }
 
 export default function PageTabs({ movie, userWithMovieIds, category }: PageTabsProps) {
-  const [activeTab, setActiveTab] = useState('overview');
+  const getInitialTab = () => {
+    switch (category) {
+      case 'reviews':
+        return 'reviews';
+      case 'ratings':
+        return 'ratings';
+      case 'expiring':
+        return 'date';
+      default:
+        return 'overview';
+    }
+  };
+
+  const [activeTab, setActiveTab] = useState(getInitialTab());
 
   const handleTabChange = useCallback((tab: string) => {
     setActiveTab(tab);


### PR DESCRIPTION
- URL category 파라미터에 따라 초기 탭이 자동 선택되도록 수정
- reviews, ratings, expiring 카테고리별 초기 탭 매핑 로직 추가
- 기본 탭을 overview로 설정

이전에는 항상 overview 탭으로 시작했던 문제를 해결하여
사용자 경험을 개선했습니다.