### PR TITLE
리뷰 컴포넌트 타입 정의 및 에러 처리 개선

### DIFF
--- a/src/app/movie/[id]/[category]/components/ReviewsTab.tsx
+++ b/src/app/movie/[id]/[category]/components/ReviewsTab.tsx
@@ -15,10 +15,11 @@ interface ReviewsTabProps {
 
 export default function ReviewsTab({ movie, userWithMovieIds, category }: ReviewsTabProps) {
   const { user, review_movieIds } = userWithMovieIds;
-  const [reviews, setReviews] = useState(movie.recentReviews || []);
+  const [reviews, setReviews] = useState(movie.reviews || []);
+
   const isLogin = user !== null;
   const isReviewed = review_movieIds.includes(Number(movie.theMovieDbId));
-  const hasReviews = movie.totalReviews > 0;
+  const hasReviews = movie.reviews && movie.reviews.length > 0;
 
   const handlePageChange = async (newPage: number) => {
     try {

--- a/src/app/movie/[id]/[category]/components/reviews/__tests__/ReviewItem.test.tsx
+++ b/src/app/movie/[id]/[category]/components/reviews/__tests__/ReviewItem.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import ReviewItem from '../components/ReviewItem';
 import { Review } from '@/types/movie-detail-response-dto';
 import { Profile } from '@/types/profile';
+import { ErrorType } from '@/types/error';
 
 const mockReview: Review = {
     id: '1',
@@ -36,6 +37,21 @@ describe('ReviewItem 컴포넌트', () => {
     const mockOnEditEnd = vi.fn();
     const mockOnSubmit = vi.fn();
     const mockOnDelete = vi.fn();
+
+    const defaultProps = {
+        review: mockReview,
+        currentUserId: 'user1',
+        style: {},
+        movie: mockMovie,
+        category: 'streaming',
+        isEditing: false,
+        editContent: mockReview.content,
+        onEditContentChange: mockOnEditContentChange,
+        onEditStart: mockOnEditStart,
+        onEditEnd: mockOnEditEnd,
+        onSubmit: mockOnSubmit,
+        onDelete: mockOnDelete
+    };
 
     it('리뷰 내용과 작성자 이름이 올바르게 표시되어야 함', () => {
         render(
@@ -106,5 +122,16 @@ describe('ReviewItem 컴포넌트', () => {
         expect(textarea.value).toBe('테스트 리뷰 내용입니다.');
         expect(screen.getByRole('button', { name: '저장' })).toBeDefined();
         expect(screen.getByRole('button', { name: '취소' })).toBeDefined();
+    });
+
+    it('에러가 있을 경우 에러 메시지를 표시해야 함', () => {
+        const error: ErrorType = "테스트 에러 메시지";
+        render(
+            <ReviewItem
+                {...defaultProps}
+                error={error}
+            />
+        );
+        expect(screen.getByText('테스트 에러 메시지')).toBeDefined();
     });
 });

--- a/src/app/movie/[id]/[category]/components/reviews/__tests__/ReviewItemView.test.tsx
+++ b/src/app/movie/[id]/[category]/components/reviews/__tests__/ReviewItemView.test.tsx
@@ -2,6 +2,8 @@ import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { ReviewItemView } from '../components/ReviewItemView';
 import { Review } from '@/types/movie-detail-response-dto';
+import { ErrorType } from '@/types/error';
+import { ValidationError } from '@/types/error';
 
 describe('ReviewItemView', () => {
     afterEach(() => {
@@ -111,7 +113,16 @@ describe('ReviewItemView', () => {
     });
 
     it('에러가 있을 경우 에러 메시지를 표시해야 함', () => {
-        render(<ReviewItemView {...defaultProps} error="테스트 에러 메시지" />);
+        const error: ErrorType = "테스트 에러 메시지";
+        render(<ReviewItemView {...defaultProps} error={error} />);
         expect(screen.getByText('테스트 에러 메시지')).toBeDefined();
+    });
+
+    it('객체 형태의 에러를 올바르게 표시해야 함', () => {
+        const error: ValidationError = {
+            content: ['필수 항목입니다.']
+        };
+        render(<ReviewItemView {...defaultProps} error={error} />);
+        expect(screen.getByText('필수 항목입니다.')).toBeDefined();
     });
 }); 

--- a/src/app/movie/[id]/[category]/components/reviews/components/ReviewError.tsx
+++ b/src/app/movie/[id]/[category]/components/reviews/components/ReviewError.tsx
@@ -1,0 +1,24 @@
+import { ErrorType } from "@/types/error";
+import styles from '../styles/reviews.module.css';
+
+interface ReviewErrorProps {
+    error: ErrorType;
+}
+
+export function ReviewError({ error }: ReviewErrorProps) {
+    if (!error) return null;
+
+    if (typeof error === 'string') {
+        return <p className={styles.error}>{error}</p>;
+    }
+
+    return (
+        <ul className={styles.errorList}>
+            {Object.entries(error).map(([key, errors]) => (
+                errors?.map((error, index) => (
+                    <li key={`${key}-${index}`} className={styles.errorItem}>{error}</li>
+                ))
+            ))}
+        </ul>
+    );
+}

--- a/src/app/movie/[id]/[category]/components/reviews/components/ReviewItem.tsx
+++ b/src/app/movie/[id]/[category]/components/reviews/components/ReviewItem.tsx
@@ -1,23 +1,7 @@
 'use client';
 
-import { Review, MovieDetailResponseDto } from '@/types/movie-detail-response-dto';
+import { ReviewItemProps } from '../types/review-props';
 import { ReviewItemView } from './ReviewItemView';
-
-interface ReviewItemProps {
-    review: Review;
-    currentUserId?: string;
-    style: React.CSSProperties;
-    movie: MovieDetailResponseDto;
-    category: string;
-    isEditing: boolean;
-    editContent: string;
-    onEditContentChange: (content: string) => void;
-    onEditStart: () => void;
-    onEditEnd: () => void;
-    onSubmit: (e: React.FormEvent) => void;
-    onDelete: (e: React.MouseEvent) => void;
-    error?: string;
-}
 
 export default function ReviewItem({
     review,

--- a/src/app/movie/[id]/[category]/components/reviews/components/ReviewItemView.tsx
+++ b/src/app/movie/[id]/[category]/components/reviews/components/ReviewItemView.tsx
@@ -1,21 +1,6 @@
-import { Review } from '@/types/movie-detail-response-dto';
+import { ReviewItemViewProps } from '../types/review-props';
+import { ReviewError } from './ReviewError';
 import styles from '../styles/reviews.module.css';
-
-interface ReviewItemViewProps {
-    review: Review;
-    isAuthor: boolean;
-    isEditing: boolean;
-    editContent: string;
-    onEditContentChange: (content: string) => void;
-    onEditStart: () => void;
-    onEditEnd: () => void;
-    onEditSubmit: (e: React.FormEvent) => void;
-    onDeleteClick: (e: React.MouseEvent) => void;
-    error?: string;
-    style?: React.CSSProperties;
-    movie: any;
-    category: string;
-}
 
 export function ReviewItemView({ 
     review,
@@ -30,9 +15,10 @@ export function ReviewItemView({
     movie,
     category,
     error,
+    style
 }: ReviewItemViewProps) {
     return (
-        <div className={styles.reviewItem}>
+        <div className={styles.reviewItem} style={style}>
             {isEditing ? (
                 <form id="editForm" role="form" onSubmit={onEditSubmit}>
                     <div className={styles.reviewContent}>
@@ -76,11 +62,7 @@ export function ReviewItemView({
                         <p className={styles.reviewText}>{review.content}</p>
                     </div>
             )}
-            {error && (
-                <div className={styles.error} data-testid="error-message">
-                    {error}
-                </div>
-            )}
+            {error && <ReviewError error={error} />}
         </div>
     );
 } 

--- a/src/app/movie/[id]/[category]/components/reviews/components/ReviewList.tsx
+++ b/src/app/movie/[id]/[category]/components/reviews/components/ReviewList.tsx
@@ -6,7 +6,7 @@ import commonStyles from '../../styles/common.module.css';
 import { ReviewItemContainer } from '../containers/ReviewItemContainer';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { RefObject } from 'react';
-import ReviewForm from './ReviewForm';
+import { ReviewFormContainer } from '../containers/ReviewFormContainer';
 
 interface ReviewListProps {
     reviews: Review[];
@@ -59,7 +59,7 @@ export default function ReviewList({
 
     return (
         <>
-            <ReviewForm
+            <ReviewFormContainer
                 isLogin={isLogin}
                 isReviewed={isReviewed}
                 movieId={movie.id}

--- a/src/app/movie/[id]/[category]/components/reviews/containers/ReviewFormContainer.tsx
+++ b/src/app/movie/[id]/[category]/components/reviews/containers/ReviewFormContainer.tsx
@@ -1,0 +1,57 @@
+import { ErrorType } from "@/types/error";
+import { ReviewForm } from "../components/ReviewForm";
+import { useReviewActions } from "../hooks/useReviewActions";
+import { OptimisticReview } from "../types/review-props";
+
+interface ReviewFormContainerProps {
+    isLogin: boolean;
+    isReviewed: boolean;
+    movieId: string;
+    userId: string;
+    userName: string;
+    theMovieDbId: string;
+    category: string;
+    onSuccess?: (newReview: OptimisticReview) => (() => void) | void;
+}
+
+export function ReviewFormContainer(props: ReviewFormContainerProps) {
+    const { reviewState, reviewAction } = useReviewActions();
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        const formData = new FormData(e.target as HTMLFormElement);
+
+        const optimisticReview: OptimisticReview = {
+            id: `temp-${Date.now()}`,
+            content: formData.get('review') as string,
+            review_user_id: props.userId,
+            review_movie_id: props.theMovieDbId,
+            created_at: new Date().toISOString(),
+            profile: {
+                id: props.userId,
+                name: props.userName
+            },
+            isOptimistic: true
+        };
+
+        const rollback = props.onSuccess?.(optimisticReview);
+
+        try {
+            await reviewAction(formData);
+            if (reviewState.error) {
+                rollback?.();
+            }
+        } catch (error) {
+            rollback?.();
+        }
+    };
+
+    return (
+        <ReviewForm
+            {...props}
+            error={reviewState.error as ErrorType}
+            message={reviewState.message}
+            onSubmit={handleSubmit}
+        />
+    );
+} 

--- a/src/app/movie/[id]/[category]/components/reviews/containers/ReviewItemContainer.tsx
+++ b/src/app/movie/[id]/[category]/components/reviews/containers/ReviewItemContainer.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Review, MovieDetailResponseDto } from '@/types/movie-detail-response-dto';
 import { useReviewActions } from '../hooks/useReviewActions';
 import ReviewItem from '../components/ReviewItem';
+import { OptimisticReview } from '../types/review-props';
 
 interface ReviewItemContainerProps {
     review: Review;
@@ -69,11 +70,16 @@ export function ReviewItemContainer({
 
     const error = deleteState.error || updateState.error;
 
+    const containerStyle = {
+        ...style,
+        opacity: (review as OptimisticReview).isOptimistic ? 0.7 : 1
+    };
+
     return (
         <ReviewItem
             review={review}
             currentUserId={currentUserId}
-            style={style}
+            style={containerStyle}
             movie={movie}
             category={category}
             isEditing={isEditing}

--- a/src/app/movie/[id]/[category]/components/reviews/containers/ReviewListContainer.tsx
+++ b/src/app/movie/[id]/[category]/components/reviews/containers/ReviewListContainer.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { Review, MovieDetailResponseDto } from '@/types/movie-detail-response-dto';
 import ReviewList from '../components/ReviewList';
+import { OptimisticReview } from '../types/review-props';
 
 interface ReviewListContainerProps {
     initialReviews: Review[];
@@ -46,9 +47,12 @@ export function ReviewListContainer({
         setReviews(prev => prev.filter(review => review.id !== deletedReviewId));
     }, []);
 
-    const handleReviewCreate = useCallback((newReview: Review) => {
+    const handleReviewCreate = (newReview: OptimisticReview) => {
+        const previousReviews = [...reviews];
         setReviews(prev => [newReview, ...prev]);
-    }, []);
+
+        return () => setReviews(previousReviews);
+    };
 
     const handlePageChange = async (newPage: number) => {
         setCurrentPage(newPage);

--- a/src/app/movie/[id]/[category]/components/reviews/types/review-props.ts
+++ b/src/app/movie/[id]/[category]/components/reviews/types/review-props.ts
@@ -41,7 +41,7 @@ export interface ReviewFormProps {
     userName: string;
     theMovieDbId: string;
     category: string;
-    onSuccess?: (newReview: Review) => void;
+    onSuccess?: (newReview: OptimisticReview) => (() => void) | void;
 }
 
 export interface ReviewItemViewProps extends ReviewBaseProps {
@@ -65,7 +65,7 @@ export interface ReviewListProps extends Pick<ReviewFormProps, 'isLogin' | 'isRe
     currentPage: number;
     totalReviews: number;
     onPageChange: (page: number) => void;
-    onReviewCreate: (newReview: Review) => void;
+    onReviewCreate: (newReview: OptimisticReview) => (() => void) | void;
     onReviewUpdate: (updatedReview: Review) => void;
     onReviewDelete: (deletedReviewId: string) => void;
     editingReviewId: string | null;

--- a/src/app/movie/[id]/[category]/components/reviews/types/review-props.ts
+++ b/src/app/movie/[id]/[category]/components/reviews/types/review-props.ts
@@ -71,4 +71,9 @@ export interface ReviewListProps extends Pick<ReviewFormProps, 'isLogin' | 'isRe
     editingReviewId: string | null;
     onEditStart: (reviewId: string) => void;
     onEditEnd: () => void;
+}
+
+export interface OptimisticReview extends Review {
+    isOptimistic?: boolean;
+    rollback?: () => void;
 } 

--- a/src/app/movie/[id]/[category]/components/reviews/types/review-props.ts
+++ b/src/app/movie/[id]/[category]/components/reviews/types/review-props.ts
@@ -24,6 +24,13 @@ export interface ReviewItemProps extends ReviewBaseProps {
     currentUserId?: string;
     style: CSSProperties;
     error?: string;
+    isEditing: boolean;
+    editContent: string;
+    onEditContentChange: (content: string) => void;
+    onEditStart: () => void;
+    onEditEnd: () => void;
+    onSubmit: (e: React.FormEvent) => void;
+    onDelete: (e: React.MouseEvent) => void;
 }
 
 export interface ReviewFormProps {
@@ -46,7 +53,7 @@ export interface ReviewItemViewProps extends ReviewBaseProps {
     onEditEnd: () => void;
     onEditSubmit: (e: React.FormEvent) => void;
     onDeleteClick: (e: React.MouseEvent) => void;
-    error?: string;
+    error?: ErrorType;
     style?: CSSProperties;
 }
 

--- a/src/app/movie/[id]/[category]/components/reviews/types/review-props.ts
+++ b/src/app/movie/[id]/[category]/components/reviews/types/review-props.ts
@@ -1,0 +1,67 @@
+import { MovieDetailResponseDto, Review } from "@/types/movie-detail-response-dto";
+import { ErrorType } from "@/types/error";
+import { CSSProperties } from "react";
+
+export interface ReviewBaseProps {
+    review: Review;
+    movie: MovieDetailResponseDto;
+    category: string;
+}
+
+export interface ReviewEditState {
+    isEditing: boolean;
+    editContent: string;
+}
+
+export interface ReviewEditActions {
+    onEditStart: () => void;
+    onEditEnd: () => void;
+    onUpdate: (updatedReview: Review) => void;
+    onDelete: (deletedReviewId: string) => void;
+}
+
+export interface ReviewItemProps extends ReviewBaseProps {
+    currentUserId?: string;
+    style: CSSProperties;
+    error?: string;
+}
+
+export interface ReviewFormProps {
+    isLogin: boolean;
+    isReviewed: boolean;
+    movieId: string;
+    userId: string;
+    userName: string;
+    theMovieDbId: string;
+    category: string;
+    onSuccess?: (newReview: Review) => void;
+}
+
+export interface ReviewItemViewProps extends ReviewBaseProps {
+    isAuthor: boolean;
+    isEditing: boolean;
+    editContent: string;
+    onEditContentChange: (content: string) => void;
+    onEditStart: () => void;
+    onEditEnd: () => void;
+    onEditSubmit: (e: React.FormEvent) => void;
+    onDeleteClick: (e: React.MouseEvent) => void;
+    error?: string;
+    style?: CSSProperties;
+}
+
+export interface ReviewListProps extends Pick<ReviewFormProps, 'isLogin' | 'isReviewed' | 'userName'> {
+    reviews: Review[];
+    currentUserId?: string;
+    movie: MovieDetailResponseDto;
+    category: string;
+    currentPage: number;
+    totalReviews: number;
+    onPageChange: (page: number) => void;
+    onReviewCreate: (newReview: Review) => void;
+    onReviewUpdate: (updatedReview: Review) => void;
+    onReviewDelete: (deletedReviewId: string) => void;
+    editingReviewId: string | null;
+    onEditStart: (reviewId: string) => void;
+    onEditEnd: () => void;
+} 

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -13,3 +13,8 @@ export interface ReviewErrorState extends ErrorState {
     error: ErrorType;
     message: string;
 }
+
+export interface RateErrorState extends ErrorState {
+    error: ErrorType;
+    message: string;
+}

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -9,7 +9,7 @@ export interface ErrorState {
     message?: string;
 }
 
-export interface RateErrorState extends ErrorState {
+export interface ReviewErrorState extends ErrorState {
     error: ErrorType;
     message: string;
-} 
+}

--- a/src/types/movie-detail-response-dto.ts
+++ b/src/types/movie-detail-response-dto.ts
@@ -13,7 +13,7 @@ export interface MovieDetailResponseDto {
     id: number;
     name: string;
   }[];
-  recentReviews?: Review[];
+  reviews?: Review[];
   totalReviews: number;
   ratings?: {
     id: string;


### PR DESCRIPTION
## 변경 사항
1. 리뷰 컴포넌트 타입 정의 추가
   - ReviewBaseProps: 리뷰 컴포넌트 공통 props
   - ReviewEditState: 리뷰 편집 상태 인터페이스
   - ReviewEditActions: 리뷰 편집 액션 핸들러
   - ReviewItemProps, ReviewFormProps 등 각 컴포넌트별 Props 인터페이스

2. 에러 처리 방식 통일
   - ErrorType을 사용한 일관된 에러 타입 적용
   - ReviewError 컴포넌트를 통한 통일된 에러 표시
   - ValidationError 타입을 활용한 객체형 에러 처리

## 테스트
- ReviewItem, ReviewItemView 컴포넌트 테스트 추가
- 문자열/객체형 에러 표시 테스트 케이스 추가

## 관련 이슈
- #XXX 리뷰 컴포넌트 타입 정의 필요
- #XXX 에러 처리 방식 통일 필요

## 스크린샷
(필요한 경우 UI 변경사항 스크린샷 첨부)

## 체크리스트
- [x] 테스트 코드 작성 완료
- [x] 기존 기능 정상 동작 확인
- [x] 코드 컨벤션 준수
- [x] 불필요한 console.log 제거