### PR TITLE
프로필 컴포넌트 구조 개선

### DIFF
--- a/src/app/profile/components/PasswordSection.tsx
+++ b/src/app/profile/components/PasswordSection.tsx
@@ -1,0 +1,103 @@
+'use client';
+import { useActionState } from 'react';
+import { updatePassword, type PasswordUpdateState } from '@/app/auth/lib/actions/password';
+import styles from '@/app/profile/profile.module.css';
+import { useState } from 'react';
+
+export default function PasswordSection() {
+    const [showPasswordSection, setShowPasswordSection] = useState(false);
+
+    const initialPasswordState: PasswordUpdateState = {
+        error: {},
+        message: '',
+        isPending: false,
+    }
+
+    const [passwordState, passwordFormAction] = useActionState(updatePassword, initialPasswordState);
+
+    return (
+        <div className={styles.passwordSection}>
+            <button
+                type="button"
+                onClick={() => setShowPasswordSection(!showPasswordSection)}
+                className={styles.togglePasswordButton}
+            >
+                비밀번호 변경 {showPasswordSection ? '그만하기' : '하기'}
+            </button>
+
+            {showPasswordSection && (
+                <form
+                    className={styles.passwordForm}
+                    action={passwordFormAction}
+                >
+                    <div className={styles.inputGroup}>
+                        <label htmlFor="currentPassword" className={styles.label}>
+                            현재 비밀번호
+                        </label>
+                        <input
+                            type="password"
+                            id="currentPassword"
+                            name="currentPassword"
+                            className={styles.input}
+                            placeholder="현재 비밀번호를 입력하세요"
+                        />
+                        {passwordState?.error?.currentPassword && (
+                            <p className={styles.error}>{passwordState.error.currentPassword[0]}</p>
+                        )}
+                    </div>
+
+                    <div className={styles.inputGroup}>
+                        <label htmlFor="newPassword" className={styles.label}>
+                            새 비밀번호
+                        </label>
+                        <input
+                            type="password"
+                            id="newPassword"
+                            name="newPassword"
+                            className={styles.input}
+                            placeholder="새 비밀번호를 입력하세요"
+                        />
+                        {passwordState?.error?.newPassword && (
+                            <p className={styles.error}>{passwordState.error.newPassword[0]}</p>
+                        )}
+                        <p className={styles.inputDescription}>
+                            비밀번호는 최소 8자 이상이며, 특수문자를 포함해야 합니다
+                        </p>
+                    </div>
+
+                    <div className={styles.inputGroup}>
+                        <label htmlFor="confirmPassword" className={styles.label}>
+                            새 비밀번호 확인
+                        </label>
+                        <input
+                            type="password"
+                            id="confirmPassword"
+                            name="confirmPassword"
+                            className={styles.input}
+                            placeholder="새 비밀번호를 다시 입력하세요"
+                        />
+                        {passwordState?.error?.confirmPassword && (
+                            <p className={styles.error}>{passwordState.error.confirmPassword[0]}</p>
+                        )}
+                    </div>
+
+                    <div className={styles.buttonGroup}>
+                        <button
+                            type="submit"
+                            className={`${styles.saveButton}`}
+                            disabled={passwordState?.isPending}
+                        >
+                            {passwordState?.isPending ? '변경 중...' : '비밀번호 변경'}
+                        </button>
+                    </div>
+
+                    {passwordState?.message && (
+                        <p className={passwordState.error ? styles.error : styles.message}>
+                            {passwordState.message}
+                        </p>
+                    )}
+                </form>
+            )}
+        </div>
+    );
+} 

--- a/src/app/profile/components/ProfileImageSection.tsx
+++ b/src/app/profile/components/ProfileImageSection.tsx
@@ -1,0 +1,79 @@
+'use client';
+import Image from 'next/image';
+import { useRef, useState } from 'react';
+import styles from '@/app/profile/profile.module.css';
+
+interface ProfileImageSectionProps {
+    imageUrl?: string;
+    name?: string;
+    onImageChange: (file: File | null) => void;
+}
+
+export default function ProfileImageSection({
+    imageUrl,
+    name,
+    onImageChange
+}: ProfileImageSectionProps) {
+    const [previewImage, setPreviewImage] = useState<string | null>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        if (file) {
+            const reader = new FileReader();
+            reader.onloadend = () => {
+                setPreviewImage(reader.result as string);
+            };
+            reader.readAsDataURL(file);
+            onImageChange(file);
+        }
+    };
+
+    const handleImageDelete = () => {
+        setPreviewImage(null);
+        if (fileInputRef.current) {
+            fileInputRef.current.value = '';
+        }
+        onImageChange(null);
+    };
+
+    return (
+        <div className={styles.imageSection}>
+            {previewImage || imageUrl ? (
+                <Image
+                    src={previewImage || imageUrl || ''}
+                    alt="프로필 이미지"
+                    width={200}
+                    height={200}
+                    unoptimized
+                    className={styles.profileImage}
+                />
+            ) : (
+                <div className={styles.profileImagePlaceholder}>
+                    {name ? name[0].toUpperCase() : '?'}
+                </div>
+            )}
+            <input
+                type="file"
+                accept="image/*"
+                name="image"
+                id="image"
+                className={styles.imageInput}
+                onChange={handleImageChange}
+                ref={fileInputRef}
+            />
+            <label htmlFor="image" className={styles.changeImageButton}>
+                이미지 변경
+            </label>
+            {previewImage && (
+                <button
+                    type="button"
+                    onClick={handleImageDelete}
+                    className={styles.deleteImageButton}
+                >
+                    이미지 삭제
+                </button>
+            )}
+        </div>
+    );
+} 

--- a/src/app/profile/components/ProfileInfoSection.tsx
+++ b/src/app/profile/components/ProfileInfoSection.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { useActionState } from 'react';
-import { updateProfile, type UploadProfileImageState } from '@/app/auth/lib/actions/profile';
+
 import styles from '@/app/profile/profile.module.css';
 import Link from 'next/link';
 
@@ -8,14 +7,12 @@ interface ProfileInfoSectionProps {
     name?: string;
     id?: string;
     isPending?: boolean;
-    onSubmit: (formData: FormData) => void;
 }
 
 export default function ProfileInfoSection({
     name,
     id,
     isPending,
-    onSubmit
 }: ProfileInfoSectionProps) {
     return (
         <div className={styles.infoSection}>

--- a/src/app/profile/components/ProfileInfoSection.tsx
+++ b/src/app/profile/components/ProfileInfoSection.tsx
@@ -1,0 +1,52 @@
+'use client';
+import { useActionState } from 'react';
+import { updateProfile, type UploadProfileImageState } from '@/app/auth/lib/actions/profile';
+import styles from '@/app/profile/profile.module.css';
+import Link from 'next/link';
+
+interface ProfileInfoSectionProps {
+    name?: string;
+    id?: string;
+    isPending?: boolean;
+    onSubmit: (formData: FormData) => void;
+}
+
+export default function ProfileInfoSection({
+    name,
+    id,
+    isPending,
+    onSubmit
+}: ProfileInfoSectionProps) {
+    return (
+        <div className={styles.infoSection}>
+            <input type="hidden" name="id" value={id} />
+            <div className={styles.inputGroup}>
+                <label htmlFor="name" className={styles.label}>이름</label>
+                <input
+                    type="text"
+                    id="name"
+                    name="name"
+                    className={styles.input}
+                    defaultValue={name}
+                    placeholder="이름을 입력하세요"
+                />
+                <p className={styles.inputDescription}>
+                    이름은 최소 2자, 최대 20자까지 입력이 가능해요<br />
+                    수정한 정보는 다른 서비스에도 동일하게 표시돼요
+                </p>
+            </div>
+            <div className={styles.buttonGroup}>
+                <Link href="/profile" className={styles.cancelButton}>
+                    취소
+                </Link>
+                <button
+                    type="submit"
+                    className={styles.saveButton}
+                    disabled={isPending}
+                >
+                    {isPending ? '저장 중...' : '변경 저장'}
+                </button>
+            </div>
+        </div>
+    );
+} 

--- a/src/app/profile/edit/ProfileEditWrapper.tsx
+++ b/src/app/profile/edit/ProfileEditWrapper.tsx
@@ -5,11 +5,11 @@ import {
   type UploadProfileImageState 
 } from '@/app/auth/lib/actions/profile'
 import styles from '@/app/profile/profile.module.css';
-import Link from 'next/link';
 import { useState, useRef, useCallback} from 'react';
 import localFont from 'next/font/local';
 import ProfileImageSection from '../components/ProfileImageSection';
 import PasswordSection from '../components/PasswordSection';
+import ProfileInfoSection from '../components/ProfileInfoSection';
 
 const doHyeon = localFont({
   src: '../../fonts/DoHyeon-Regular.ttf',
@@ -60,26 +60,12 @@ export default function ProfileEdit({ name, image_url, id }: ProfileEditProps) {
               name={state.name}
               onImageChange={handleImageUpdate}
             />
-            <div className={styles.infoSection}>
-              <div className={styles.inputGroup}>
-                <label htmlFor="name" className={styles.label}>이름</label>
-                <input
-                  type="text"
-                  id="name"
-                  name="name"
-                  className={styles.input}
-                  defaultValue={state.name}
-                  placeholder="이름을 입력하세요"
-                />
-                <p className={styles.inputDescription}>이름은 최소 2자, 최대 20자까지 입력이 가능해요<br />수정한 정보는 다른 서비스에도 동일하게 표시돼요</p>
-              </div>
-              <div className={styles.buttonGroup}>
-                <Link href="/profile" className={styles.cancelButton}>취소</Link>
-                <button type="submit" className={`${styles.saveButton} ${doHyeon.className}`} disabled={state?.isPending}>
-                  {state?.isPending ? '저장 중...' : '변경 저장'}
-                </button>
-              </div>
-            </div>
+            <ProfileInfoSection
+              name={state.name}
+              id={state.id}
+              isPending={state.isPending}
+              onSubmit={handleSubmit}
+            />
           </div>
         </form>
 

--- a/src/app/profile/edit/ProfileEditWrapper.tsx
+++ b/src/app/profile/edit/ProfileEditWrapper.tsx
@@ -64,7 +64,6 @@ export default function ProfileEdit({ name, image_url, id }: ProfileEditProps) {
               name={state.name}
               id={state.id}
               isPending={state.isPending}
-              onSubmit={handleSubmit}
             />
           </div>
         </form>

--- a/src/app/profile/edit/ProfileEditWrapper.tsx
+++ b/src/app/profile/edit/ProfileEditWrapper.tsx
@@ -13,6 +13,7 @@ import styles from '@/app/profile/profile.module.css';
 import Link from 'next/link';
 import { useState, useRef, useCallback} from 'react';
 import localFont from 'next/font/local';
+import ProfileImageSection from '../components/ProfileImageSection';
 
 const doHyeon = localFont({
   src: '../../fonts/DoHyeon-Regular.ttf',
@@ -54,21 +55,11 @@ export default function ProfileEdit({ name, image_url, id }: ProfileEditProps) {
 
   const [passwordState, passwordFormAction] = useActionState(updatePassword, initialPasswordState);
 
-  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
+  const handleImageUpdate = (file: File | null) => {
     if (file) {
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        setPreviewImage(reader.result as string);
-      };
-      reader.readAsDataURL(file);
-    }
-  };
-
-  const handleImageDelete = () => {
-    setPreviewImage(null);
-    if (fileInputRef.current) {
-      fileInputRef.current.value = '';
+      const formData = new FormData();
+      formData.append('image', file);
+      formAction(formData);
     }
   };
 
@@ -84,38 +75,11 @@ export default function ProfileEdit({ name, image_url, id }: ProfileEditProps) {
       <div className={styles.profileContent}>
         <form className={styles.form} action={handleSubmit}>
           <div className={styles.profileLayout}>
-            <div className={styles.imageSection}>
-              <input type="hidden" name="id" value={state.id} />
-              {previewImage || state?.imageUrl ? (
-                <Image
-                  src={previewImage || state.imageUrl || ''}
-                  alt="프로필 이미지"
-                  width={200}
-                  height={200}
-                  unoptimized
-                  className={styles.profileImage}
-                />
-              ) : (
-                <div className={styles.profileImagePlaceholder}>
-                  {state.name ? state.name[0].toUpperCase() : '?'}
-                </div>
-              )}
-              <input
-                type="file"
-                accept="image/*"
-                name="image"
-                id="image"
-                className={styles.imageInput}
-                onChange={handleImageChange}
-                ref={fileInputRef}
-              />
-              <label htmlFor="image" className={styles.changeImageButton}>이미지 변경</label>
-              {previewImage && (
-                <button type="button" onClick={handleImageDelete} className={styles.deleteImageButton}>
-                  이미지 삭제
-                </button>
-              )}
-            </div>
+            <ProfileImageSection
+              imageUrl={state.imageUrl}
+              name={state.name}
+              onImageChange={handleImageUpdate}
+            />
             <div className={styles.infoSection}>
               <div className={styles.inputGroup}>
                 <label htmlFor="name" className={styles.label}>이름</label>

--- a/src/app/profile/edit/ProfileEditWrapper.tsx
+++ b/src/app/profile/edit/ProfileEditWrapper.tsx
@@ -1,19 +1,15 @@
 'use client';
-import Image from 'next/image';
 import { useActionState } from 'react';
 import { 
   updateProfile, 
   type UploadProfileImageState 
 } from '@/app/auth/lib/actions/profile'
-import { 
-  updatePassword, 
-  type PasswordUpdateState 
-} from '@/app/auth/lib/actions/password'
 import styles from '@/app/profile/profile.module.css';
 import Link from 'next/link';
 import { useState, useRef, useCallback} from 'react';
 import localFont from 'next/font/local';
 import ProfileImageSection from '../components/ProfileImageSection';
+import PasswordSection from '../components/PasswordSection';
 
 const doHyeon = localFont({
   src: '../../fonts/DoHyeon-Regular.ttf',
@@ -24,12 +20,6 @@ interface ProfileEditProps {
   name: string;
   image_url: string;
   id: string;
-}
-
-interface PasswordSection {
-  currentPassword: string;
-  newPassword: string;
-  confirmPassword: string;
 }
 
 export default function ProfileEdit({ name, image_url, id }: ProfileEditProps) {
@@ -44,16 +34,6 @@ export default function ProfileEdit({ name, image_url, id }: ProfileEditProps) {
   const [state, formAction] = useActionState(updateProfile, initialState);
   const [previewImage, setPreviewImage] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [showPasswordSection, setShowPasswordSection] = useState(false);
-  const [passwordError, setPasswordError] = useState<string>('');
-
-  const initialPasswordState: PasswordUpdateState = {
-    error: {},
-    message: '',
-    isPending: false,
-  }
-
-  const [passwordState, passwordFormAction] = useActionState(updatePassword, initialPasswordState);
 
   const handleImageUpdate = (file: File | null) => {
     if (file) {
@@ -103,89 +83,7 @@ export default function ProfileEdit({ name, image_url, id }: ProfileEditProps) {
           </div>
         </form>
 
-        <div className={styles.passwordSection}>
-          <button
-            type="button"
-            onClick={() => setShowPasswordSection(!showPasswordSection)}
-            className={styles.togglePasswordButton}
-          >
-            비밀번호 변경 {showPasswordSection ? '그만하기' : '하기'}
-          </button>
-
-          {showPasswordSection && (
-            <form
-              className={styles.passwordForm}
-              action={passwordFormAction}
-            >
-              <div className={styles.inputGroup}>
-                <label htmlFor="currentPassword" className={styles.label}>
-                  현재 비밀번호
-                </label>
-                <input
-                  type="password"
-                  id="currentPassword"
-                  name="currentPassword"
-                  className={styles.input}
-                  placeholder="현재 비밀번호를 입력하세요"
-                />
-                {passwordState?.error?.currentPassword && (
-                  <p className={styles.error}>{passwordState.error.currentPassword[0]}</p>
-                )}
-              </div>
-
-              <div className={styles.inputGroup}>
-                <label htmlFor="newPassword" className={styles.label}>
-                  새 비밀번호
-                </label>
-                <input
-                  type="password"
-                  id="newPassword"
-                  name="newPassword"
-                  className={styles.input}
-                  placeholder="새 비밀번호를 입력하세요"
-                />
-                {passwordState?.error?.newPassword && (
-                  <p className={styles.error}>{passwordState.error.newPassword[0]}</p>
-                )}
-                <p className={styles.inputDescription}>
-                  비밀번호는 최소 8자 이상이며, 특수문자를 포함해야 합니다
-                </p>
-              </div>
-
-              <div className={styles.inputGroup}>
-                <label htmlFor="confirmPassword" className={styles.label}>
-                  새 비밀번호 확인
-                </label>
-                <input
-                  type="password"
-                  id="confirmPassword"
-                  name="confirmPassword"
-                  className={styles.input}
-                  placeholder="새 비밀번호를 다시 입력하세요"
-                />
-                {passwordState?.error?.confirmPassword && (
-                  <p className={styles.error}>{passwordState.error.confirmPassword[0]}</p>
-                )}
-              </div>
-
-              <div className={styles.buttonGroup}>
-                <button
-                  type="submit" 
-                  className={`${styles.saveButton} ${doHyeon.className}`}
-                  disabled={passwordState?.isPending}
-                >
-                  {passwordState?.isPending ? '변경 중...' : '비밀번호 변경'}
-                </button>
-              </div>
-
-              {passwordState?.message && (
-                <p className={passwordState.error ? styles.error : styles.message}>
-                  {passwordState.message}
-                </p>
-              )}
-            </form>
-          )}
-        </div>
+        <PasswordSection />
 
         {state?.message && <p className={styles.message}>{state.message}</p>}
       </div>


### PR DESCRIPTION
# 프로필 컴포넌트 구조 개선

## 변경 사항
프로필 페이지의 컴포넌트 구조를 개선하여 유지보수성과 재사용성을 향상시켰습니다.

### 컴포넌트 분리
- `ProfileImageSection`: 프로필 이미지 관리
- `ProfileInfoSection`: 프로필 정보 수정
- `PasswordSection`: 비밀번호 변경

### 코드 개선
- 각 컴포넌트의 책임 명확화
- Props 타입 정의 개선
- 불필요한 코드 제거

## 테스트 항목
- [ ] 프로필 이미지 업로드/삭제
- [ ] 프로필 정보 수정
- [ ] 비밀번호 변경
- [ ] 모바일/데스크톱 레이아웃