### PR TITLE
 프로필 관련 커스텀 훅 분리

### DIFF
--- a/src/app/profile/components/PasswordSection.tsx
+++ b/src/app/profile/components/PasswordSection.tsx
@@ -1,25 +1,20 @@
 'use client';
-import { useActionState } from 'react';
-import { updatePassword, type PasswordUpdateState } from '@/app/auth/lib/actions/password';
 import styles from '@/app/profile/profile.module.css';
-import { useState } from 'react';
+import { usePasswordForm } from '../hooks/usePasswordForm';
 
 export default function PasswordSection() {
-    const [showPasswordSection, setShowPasswordSection] = useState(false);
-
-    const initialPasswordState: PasswordUpdateState = {
-        error: {},
-        message: '',
-        isPending: false,
-    }
-
-    const [passwordState, passwordFormAction] = useActionState(updatePassword, initialPasswordState);
+    const {
+        showPasswordSection,
+        togglePasswordSection,
+        passwordState,
+        passwordFormAction
+    } = usePasswordForm();
 
     return (
         <div className={styles.passwordSection}>
             <button
                 type="button"
-                onClick={() => setShowPasswordSection(!showPasswordSection)}
+                onClick={togglePasswordSection}
                 className={styles.togglePasswordButton}
             >
                 비밀번호 변경 {showPasswordSection ? '그만하기' : '하기'}
@@ -84,7 +79,7 @@ export default function PasswordSection() {
                     <div className={styles.buttonGroup}>
                         <button
                             type="submit"
-                            className={`${styles.saveButton}`}
+                            className={styles.saveButton}
                             disabled={passwordState?.isPending}
                         >
                             {passwordState?.isPending ? '변경 중...' : '비밀번호 변경'}

--- a/src/app/profile/components/ProfileImageSection.tsx
+++ b/src/app/profile/components/ProfileImageSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 import Image from 'next/image';
-import { useRef, useState } from 'react';
 import styles from '@/app/profile/profile.module.css';
+import { useProfileImage } from '../hooks/useProfileImage';
 
 interface ProfileImageSectionProps {
     imageUrl?: string;
@@ -14,28 +14,12 @@ export default function ProfileImageSection({
     name,
     onImageChange
 }: ProfileImageSectionProps) {
-    const [previewImage, setPreviewImage] = useState<string | null>(null);
-    const fileInputRef = useRef<HTMLInputElement>(null);
-
-    const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        const file = event.target.files?.[0];
-        if (file) {
-            const reader = new FileReader();
-            reader.onloadend = () => {
-                setPreviewImage(reader.result as string);
-            };
-            reader.readAsDataURL(file);
-            onImageChange(file);
-        }
-    };
-
-    const handleImageDelete = () => {
-        setPreviewImage(null);
-        if (fileInputRef.current) {
-            fileInputRef.current.value = '';
-        }
-        onImageChange(null);
-    };
+    const {
+        previewImage,
+        fileInputRef,
+        handleImageChange,
+        handleImageDelete
+    } = useProfileImage({ onImageChange });
 
     return (
         <div className={styles.imageSection}>

--- a/src/app/profile/edit/ProfileEditWrapper.tsx
+++ b/src/app/profile/edit/ProfileEditWrapper.tsx
@@ -1,15 +1,10 @@
 'use client';
-import { useActionState } from 'react';
-import { 
-  updateProfile, 
-  type UploadProfileImageState 
-} from '@/app/auth/lib/actions/profile'
 import styles from '@/app/profile/profile.module.css';
-import { useState, useRef, useCallback} from 'react';
 import localFont from 'next/font/local';
 import ProfileImageSection from '../components/ProfileImageSection';
 import PasswordSection from '../components/PasswordSection';
 import ProfileInfoSection from '../components/ProfileInfoSection';
+import { useProfileForm } from '../hooks/useProfileForm';
 
 const doHyeon = localFont({
   src: '../../fonts/DoHyeon-Regular.ttf',
@@ -23,32 +18,11 @@ interface ProfileEditProps {
 }
 
 export default function ProfileEdit({ name, image_url, id }: ProfileEditProps) {
-  const initialState: UploadProfileImageState = {
-    error: '',
-    message: '',
-    imageUrl: image_url || '',
-    name: name || '',
-    isPending: false,
-    id: id || '',
-  }
-  const [state, formAction] = useActionState(updateProfile, initialState);
-  const [previewImage, setPreviewImage] = useState<string | null>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const handleImageUpdate = (file: File | null) => {
-    if (file) {
-      const formData = new FormData();
-      formData.append('image', file);
-      formAction(formData);
-    }
-  };
-
-  const handleSubmit = useCallback((formData: FormData) => {
-    if (!previewImage && state.imageUrl) {
-      formData.set('image', state.imageUrl);
-    }
-    formAction(formData);
-  }, [formAction, previewImage, state.imageUrl]);
+  const { state, handleImageUpdate, handleSubmit } = useProfileForm({
+    name,
+    image_url,
+    id,
+  });
 
   return (
     <div className={`${styles.profileContainer} ${doHyeon.className}`}>

--- a/src/app/profile/hooks/usePasswordForm.ts
+++ b/src/app/profile/hooks/usePasswordForm.ts
@@ -1,0 +1,34 @@
+'use client';
+import { useActionState } from 'react';
+import { updatePassword, type PasswordUpdateState } from '@/app/auth/lib/actions/password';
+import { useState } from 'react';
+
+interface UsePasswordFormReturn {
+    showPasswordSection: boolean;
+    togglePasswordSection: () => void;
+    passwordState: PasswordUpdateState;
+    passwordFormAction: (formData: FormData) => void;
+}
+
+export function usePasswordForm(): UsePasswordFormReturn {
+    const [showPasswordSection, setShowPasswordSection] = useState(false);
+
+    const initialPasswordState: PasswordUpdateState = {
+        error: {},
+        message: '',
+        isPending: false,
+    }
+
+    const [passwordState, passwordFormAction] = useActionState(updatePassword, initialPasswordState);
+
+    const togglePasswordSection = () => {
+        setShowPasswordSection(!showPasswordSection);
+    };
+
+    return {
+        showPasswordSection,
+        togglePasswordSection,
+        passwordState,
+        passwordFormAction,
+    };
+} 

--- a/src/app/profile/hooks/useProfileForm.ts
+++ b/src/app/profile/hooks/useProfileForm.ts
@@ -1,0 +1,47 @@
+'use client';
+import { useActionState } from 'react';
+import { updateProfile, type UploadProfileImageState } from '@/app/auth/lib/actions/profile';
+import { useCallback } from 'react';
+
+interface UseProfileFormProps {
+    name: string;
+    image_url: string;
+    id: string;
+}
+
+interface UseProfileFormReturn {
+    state: UploadProfileImageState;
+    handleImageUpdate: (file: File | null) => void;
+    handleSubmit: (formData: FormData) => void;
+}
+
+export function useProfileForm({ name, image_url, id }: UseProfileFormProps): UseProfileFormReturn {
+    const initialState: UploadProfileImageState = {
+        error: '',
+        message: '',
+        imageUrl: image_url || '',
+        name: name || '',
+        isPending: false,
+        id: id || '',
+    }
+
+    const [state, formAction] = useActionState(updateProfile, initialState);
+
+    const handleImageUpdate = (file: File | null) => {
+        if (file) {
+            const formData = new FormData();
+            formData.append('image', file);
+            formAction(formData);
+        }
+    };
+
+    const handleSubmit = useCallback((formData: FormData) => {
+        formAction(formData);
+    }, [formAction]);
+
+    return {
+        state,
+        handleImageUpdate,
+        handleSubmit,
+    };
+} 

--- a/src/app/profile/hooks/useProfileImage.ts
+++ b/src/app/profile/hooks/useProfileImage.ts
@@ -1,0 +1,45 @@
+'use client';
+import { useState, useRef } from 'react';
+
+interface UseProfileImageProps {
+    onImageChange: (file: File | null) => void;
+}
+
+interface UseProfileImageReturn {
+    previewImage: string | null;
+    fileInputRef: React.RefObject<HTMLInputElement>;
+    handleImageChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    handleImageDelete: () => void;
+}
+
+export function useProfileImage({ onImageChange }: UseProfileImageProps): UseProfileImageReturn {
+    const [previewImage, setPreviewImage] = useState<string | null>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        if (file) {
+            const reader = new FileReader();
+            reader.onloadend = () => {
+                setPreviewImage(reader.result as string);
+            };
+            reader.readAsDataURL(file);
+            onImageChange(file);
+        }
+    };
+
+    const handleImageDelete = () => {
+        setPreviewImage(null);
+        if (fileInputRef.current) {
+            fileInputRef.current.value = '';
+        }
+        onImageChange(null);
+    };
+
+    return {
+        previewImage,
+        fileInputRef,
+        handleImageChange,
+        handleImageDelete,
+    };
+} 


### PR DESCRIPTION
# 프로필 관련 커스텀 훅 분리

## 변경 사항
프로필 페이지의 로직을 커스텀 훅으로 분리하여 코드의 재사용성과 유지보수성을 향상시켰습니다.

### 커스텀 훅 추가
- `useProfileImage`: 이미지 업로드/미리보기/삭제 로직
- `usePasswordForm`: 비밀번호 변경 폼 상태 관리
- `useProfileForm`: 프로필 정보 수정 폼 상태 관리

### 컴포넌트 개선
- 각 컴포넌트에서 비즈니스 로직을 분리
- UI 렌더링에 집중하도록 구조 개선
- 불필요한 코드 및 import 정리

## 테스트 항목
- [x] 프로필 이미지 업로드/미리보기/삭제 기능
- [x] 프로필 정보 수정 기능
- [x] 비밀번호 변경 기능
- [x] 각 폼의 상태 관리 및 에러 처리