### PR TITLE
프로필 페이지 공통 컴포넌트 분리 및 레이아웃 개선

### DIFF
--- a/src/app/profile/components/FormButton.tsx
+++ b/src/app/profile/components/FormButton.tsx
@@ -1,0 +1,46 @@
+'use client';
+import styles from '@/app/profile/profile.module.css';
+import Link from 'next/link';
+
+interface FormButtonProps {
+    type?: 'submit' | 'button';
+    variant: 'primary' | 'secondary' | 'toggle';
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    href?: string;
+}
+
+export default function FormButton({
+    type = 'button',
+    variant,
+    children,
+    onClick,
+    disabled,
+    href
+}: FormButtonProps) {
+    const buttonStyles = {
+        primary: styles.saveButton,
+        secondary: styles.cancelButton,
+        toggle: styles.togglePasswordButton,
+    };
+
+    if (href) {
+        return (
+            <Link href={href} className={buttonStyles[variant]}>
+                {children}
+            </Link>
+        );
+    }
+
+    return (
+        <button
+            type={type}
+            className={buttonStyles[variant]}
+            onClick={onClick}
+            disabled={disabled}
+        >
+            {children}
+        </button>
+    );
+} 

--- a/src/app/profile/components/FormField.tsx
+++ b/src/app/profile/components/FormField.tsx
@@ -1,5 +1,6 @@
 'use client';
 import styles from '@/app/profile/profile.module.css';
+import FormMessage from './FormMessage';
 
 interface FormFieldProps {
     label: string;
@@ -34,14 +35,14 @@ export default function FormField({
                 placeholder={placeholder}
             />
             {description && (
-                <p className={styles.inputDescription}>
+                <FormMessage type="description">
                     {description}
-                </p>
+                </FormMessage>
             )}
             {error && (
-                <p className={styles.error}>
+                <FormMessage type="error">
                     {error}
-                </p>
+                </FormMessage>
             )}
         </div>
     );

--- a/src/app/profile/components/FormField.tsx
+++ b/src/app/profile/components/FormField.tsx
@@ -1,0 +1,48 @@
+'use client';
+import styles from '@/app/profile/profile.module.css';
+
+interface FormFieldProps {
+    label: string;
+    name: string;
+    type: 'text' | 'password';
+    value?: string;
+    placeholder?: string;
+    description?: string;
+    error?: string;
+}
+
+export default function FormField({
+    label,
+    name,
+    type,
+    value,
+    placeholder,
+    description,
+    error
+}: FormFieldProps) {
+    return (
+        <div className={styles.inputGroup}>
+            <label htmlFor={name} className={styles.label}>
+                {label}
+            </label>
+            <input
+                type={type}
+                id={name}
+                name={name}
+                className={styles.input}
+                defaultValue={value}
+                placeholder={placeholder}
+            />
+            {description && (
+                <p className={styles.inputDescription}>
+                    {description}
+                </p>
+            )}
+            {error && (
+                <p className={styles.error}>
+                    {error}
+                </p>
+            )}
+        </div>
+    );
+} 

--- a/src/app/profile/components/FormMessage.tsx
+++ b/src/app/profile/components/FormMessage.tsx
@@ -1,0 +1,23 @@
+'use client';
+import styles from '@/app/profile/profile.module.css';
+
+interface FormMessageProps {
+    type: 'error' | 'success' | 'description';
+    children: React.ReactNode;
+}
+
+export default function FormMessage({ type, children }: FormMessageProps) {
+    const messageStyles = {
+        error: styles.error,
+        success: styles.message,
+        description: styles.inputDescription,
+    };
+
+    if (!children) return null;
+
+    return (
+        <p className={messageStyles[type]}>
+            {children}
+        </p>
+    );
+} 

--- a/src/app/profile/components/PasswordSection.tsx
+++ b/src/app/profile/components/PasswordSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 import styles from '@/app/profile/profile.module.css';
 import { usePasswordForm } from '../hooks/usePasswordForm';
+import FormField from './FormField';
 
 export default function PasswordSection() {
     const {
@@ -25,56 +26,28 @@ export default function PasswordSection() {
                     className={styles.passwordForm}
                     action={passwordFormAction}
                 >
-                    <div className={styles.inputGroup}>
-                        <label htmlFor="currentPassword" className={styles.label}>
-                            현재 비밀번호
-                        </label>
-                        <input
-                            type="password"
-                            id="currentPassword"
-                            name="currentPassword"
-                            className={styles.input}
-                            placeholder="현재 비밀번호를 입력하세요"
-                        />
-                        {passwordState?.error?.currentPassword && (
-                            <p className={styles.error}>{passwordState.error.currentPassword[0]}</p>
-                        )}
-                    </div>
-
-                    <div className={styles.inputGroup}>
-                        <label htmlFor="newPassword" className={styles.label}>
-                            새 비밀번호
-                        </label>
-                        <input
-                            type="password"
-                            id="newPassword"
-                            name="newPassword"
-                            className={styles.input}
-                            placeholder="새 비밀번호를 입력하세요"
-                        />
-                        {passwordState?.error?.newPassword && (
-                            <p className={styles.error}>{passwordState.error.newPassword[0]}</p>
-                        )}
-                        <p className={styles.inputDescription}>
-                            비밀번호는 최소 8자 이상이며, 특수문자를 포함해야 합니다
-                        </p>
-                    </div>
-
-                    <div className={styles.inputGroup}>
-                        <label htmlFor="confirmPassword" className={styles.label}>
-                            새 비밀번호 확인
-                        </label>
-                        <input
-                            type="password"
-                            id="confirmPassword"
-                            name="confirmPassword"
-                            className={styles.input}
-                            placeholder="새 비밀번호를 다시 입력하세요"
-                        />
-                        {passwordState?.error?.confirmPassword && (
-                            <p className={styles.error}>{passwordState.error.confirmPassword[0]}</p>
-                        )}
-                    </div>
+                    <FormField
+                        label="현재 비밀번호"
+                        name="currentPassword"
+                        type="password"
+                        placeholder="현재 비밀번호를 입력하세요"
+                        error={passwordState?.error?.currentPassword?.[0]}
+                    />
+                    <FormField
+                        label="새 비밀번호"
+                        name="newPassword"
+                        type="password"
+                        placeholder="새 비밀번호를 입력하세요"
+                        description="비밀번호는 최소 8자 이상이며, 특수문자를 포함해야 합니다"
+                        error={passwordState?.error?.newPassword?.[0]}
+                    />
+                    <FormField
+                        label="새 비밀번호 확인"
+                        name="confirmPassword"
+                        type="password"
+                        placeholder="새 비밀번호를 다시 입력하세요"
+                        error={passwordState?.error?.confirmPassword?.[0]}
+                    />
 
                     <div className={styles.buttonGroup}>
                         <button

--- a/src/app/profile/components/PasswordSection.tsx
+++ b/src/app/profile/components/PasswordSection.tsx
@@ -2,6 +2,8 @@
 import styles from '@/app/profile/profile.module.css';
 import { usePasswordForm } from '../hooks/usePasswordForm';
 import FormField from './FormField';
+import FormButton from './FormButton';
+import FormMessage from './FormMessage';
 
 export default function PasswordSection() {
     const {
@@ -13,13 +15,12 @@ export default function PasswordSection() {
 
     return (
         <div className={styles.passwordSection}>
-            <button
-                type="button"
+            <FormButton
+                variant="toggle"
                 onClick={togglePasswordSection}
-                className={styles.togglePasswordButton}
             >
                 비밀번호 변경 {showPasswordSection ? '그만하기' : '하기'}
-            </button>
+            </FormButton>
 
             {showPasswordSection && (
                 <form
@@ -50,19 +51,19 @@ export default function PasswordSection() {
                     />
 
                     <div className={styles.buttonGroup}>
-                        <button
+                        <FormButton
                             type="submit"
-                            className={styles.saveButton}
+                            variant="primary"
                             disabled={passwordState?.isPending}
                         >
                             {passwordState?.isPending ? '변경 중...' : '비밀번호 변경'}
-                        </button>
+                        </FormButton>
                     </div>
 
                     {passwordState?.message && (
-                        <p className={passwordState.error ? styles.error : styles.message}>
+                        <FormMessage type={passwordState.error ? 'error' : 'success'}>
                             {passwordState.message}
-                        </p>
+                        </FormMessage>
                     )}
                 </form>
             )}

--- a/src/app/profile/components/ProfileImageSection.tsx
+++ b/src/app/profile/components/ProfileImageSection.tsx
@@ -25,7 +25,7 @@ export default function ProfileImageSection({
         <div className={styles.imageSection}>
             {previewImage || imageUrl ? (
                 <Image
-                    src={previewImage || imageUrl || ''}
+                    src={previewImage || imageUrl || '/default-profile.jpg'}
                     alt="프로필 이미지"
                     width={200}
                     height={200}

--- a/src/app/profile/components/ProfileInfoSection.tsx
+++ b/src/app/profile/components/ProfileInfoSection.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import styles from '@/app/profile/profile.module.css';
-import Link from 'next/link';
 import FormField from './FormField';
+import FormButton from './FormButton';
 
 interface ProfileInfoSectionProps {
     name?: string;
@@ -27,16 +27,19 @@ export default function ProfileInfoSection({
                 description="이름은 최소 2자, 최대 20자까지 입력이 가능해요&#13;수정한 정보는 다른 서비스에도 동일하게 표시돼요"
             />
             <div className={styles.buttonGroup}>
-                <Link href="/profile" className={styles.cancelButton}>
+                <FormButton
+                    variant="secondary"
+                    href="/profile"
+                >
                     취소
-                </Link>
-                <button
+                </FormButton>
+                <FormButton
                     type="submit"
-                    className={styles.saveButton}
+                    variant="primary"
                     disabled={isPending}
                 >
                     {isPending ? '저장 중...' : '변경 저장'}
-                </button>
+                </FormButton>
             </div>
         </div>
     );

--- a/src/app/profile/components/ProfileInfoSection.tsx
+++ b/src/app/profile/components/ProfileInfoSection.tsx
@@ -2,6 +2,7 @@
 
 import styles from '@/app/profile/profile.module.css';
 import Link from 'next/link';
+import FormField from './FormField';
 
 interface ProfileInfoSectionProps {
     name?: string;
@@ -17,21 +18,14 @@ export default function ProfileInfoSection({
     return (
         <div className={styles.infoSection}>
             <input type="hidden" name="id" value={id} />
-            <div className={styles.inputGroup}>
-                <label htmlFor="name" className={styles.label}>이름</label>
-                <input
-                    type="text"
-                    id="name"
-                    name="name"
-                    className={styles.input}
-                    defaultValue={name}
-                    placeholder="이름을 입력하세요"
-                />
-                <p className={styles.inputDescription}>
-                    이름은 최소 2자, 최대 20자까지 입력이 가능해요<br />
-                    수정한 정보는 다른 서비스에도 동일하게 표시돼요
-                </p>
-            </div>
+            <FormField
+                label="이름"
+                name="name"
+                type="text"
+                value={name}
+                placeholder="이름을 입력하세요"
+                description="이름은 최소 2자, 최대 20자까지 입력이 가능해요&#13;수정한 정보는 다른 서비스에도 동일하게 표시돼요"
+            />
             <div className={styles.buttonGroup}>
                 <Link href="/profile" className={styles.cancelButton}>
                     취소

--- a/src/app/profile/edit/ProfileEditWrapper.tsx
+++ b/src/app/profile/edit/ProfileEditWrapper.tsx
@@ -5,6 +5,7 @@ import ProfileImageSection from '../components/ProfileImageSection';
 import PasswordSection from '../components/PasswordSection';
 import ProfileInfoSection from '../components/ProfileInfoSection';
 import { useProfileForm } from '../hooks/useProfileForm';
+import FormMessage from '../components/FormMessage';
 
 const doHyeon = localFont({
   src: '../../fonts/DoHyeon-Regular.ttf',
@@ -44,7 +45,11 @@ export default function ProfileEdit({ name, image_url, id }: ProfileEditProps) {
 
         <PasswordSection />
 
-        {state?.message && <p className={styles.message}>{state.message}</p>}
+        {state?.message && (
+          <FormMessage type={state.error ? 'error' : 'success'}>
+            {state.message}
+          </FormMessage>
+        )}
       </div>
     </div>
   );

--- a/src/app/profile/hooks/useProfileForm.ts
+++ b/src/app/profile/hooks/useProfileForm.ts
@@ -1,7 +1,7 @@
 'use client';
 import { useActionState } from 'react';
 import { updateProfile, type UploadProfileImageState } from '@/app/auth/lib/actions/profile';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 
 interface UseProfileFormProps {
     name: string;
@@ -16,6 +16,8 @@ interface UseProfileFormReturn {
 }
 
 export function useProfileForm({ name, image_url, id }: UseProfileFormProps): UseProfileFormReturn {
+    const [selectedImage, setSelectedImage] = useState<File | null>(null);
+
     const initialState: UploadProfileImageState = {
         error: '',
         message: '',
@@ -28,16 +30,15 @@ export function useProfileForm({ name, image_url, id }: UseProfileFormProps): Us
     const [state, formAction] = useActionState(updateProfile, initialState);
 
     const handleImageUpdate = (file: File | null) => {
-        if (file) {
-            const formData = new FormData();
-            formData.append('image', file);
-            formAction(formData);
-        }
+        setSelectedImage(file);
     };
 
     const handleSubmit = useCallback((formData: FormData) => {
+        if (selectedImage) {
+            formData.set('image', selectedImage);
+        }
         formAction(formData);
-    }, [formAction]);
+    }, [formAction, selectedImage]);
 
     return {
         state,

--- a/src/app/profile/profile.module.css
+++ b/src/app/profile/profile.module.css
@@ -1,12 +1,11 @@
 .profileContainer {
-    width: 100%;
     max-width: 100%;
-    margin: 1rem auto;
+    margin: 0 auto;
     padding: 1rem;
     color: #fff;
-    border-radius: 8px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    border-radius: 0;
     box-sizing: border-box;
+    background-color: rgba(255, 255, 255, 0.02);
 }
 
 .title {
@@ -16,7 +15,6 @@
 }
 
 .profileContent {
-    width: 100%;
     max-width: 100%;
     margin: 0 auto;
     padding: 0.5rem;
@@ -108,6 +106,10 @@
     padding: 8px;
     font-size: 15px;
     box-sizing: border-box;
+    background-color: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 4px;
+    color: #fff;
 }
 
 .inputDescription {
@@ -145,8 +147,8 @@
 }
 
 .passwordSection {
-    margin-top: 2rem;
-    padding-top: 2rem;
+    margin-top: 1rem;
+    padding-top: 1rem;
     border-top: 1px solid rgba(255, 255, 255, 0.1);
 }
 
@@ -166,26 +168,26 @@
 }
 
 .passwordForm {
-    background: rgba(0, 0, 0, 0.2);
-    padding: 1.5rem;
-    border-radius: 8px;
     margin-top: 1rem;
 }
 
 @media (min-width: 768px) {
     .profileContainer {
-        max-width: 600px;
-        margin: 3rem auto 0;
+        max-width: 800px;
+        margin: 2rem auto;
         padding: 2rem;
+        border-radius: 8px;
+        background-color: rgba(255, 255, 255, 0.03);
     }
 
     .profileContent {
-        padding: 2rem;
+        padding: 1rem;
     }
 
     .profileLayout {
         flex-direction: row;
         gap: 2rem;
+        align-items: flex-start;
     }
 
     .imageSection {
@@ -200,19 +202,19 @@
 
     .changeImageButton, .deleteImageButton, .cancelButton, .saveButton {
         width: auto;
-        min-width: 200px;  /* 이미지 변경 버튼과 동일한 크기로 설정 */
-        padding: 12px 20px;  /* 버튼 크기를 약간 키움 */
-        font-size: 16px;  /* 폰트 크기도 약간 키움 */
+        min-width: 200px;
+        padding: 12px 20px;
+        font-size: 16px;
     }
 
     .buttonGroup {
         flex-direction: row;
         justify-content: flex-end;
-        gap: 1rem;  /* 버튼 사이의 간격을 조금 늘림 */
+        gap: 1rem;
     }
 
     .infoSection .buttonGroup {
-        justify-content: flex-start;  /* 정보 섹션의 버튼 그룹은 왼쪽 정렬 */
+        justify-content: flex-start;
     }
 
     .message, .error {
@@ -232,6 +234,11 @@
     
     .passwordForm {
         padding: 2rem;
+    }
+
+    .infoSection {
+        flex: 1;
+        min-width: 0;
     }
 }
 


### PR DESCRIPTION
## 변경 사항
프로필 페이지의 UI 컴포넌트들을 재사용 가능한 공통 컴포넌트로 분리하고, 전체적인 레이아웃과 스타일을 개선했습니다.

### 공통 컴포넌트 추가
- `FormField`: 입력 필드, 라벨, 설명, 에러 메시지를 포함한 통합 폼 컴포넌트
- `FormMessage`: 에러/성공/설명 메시지를 일관되게 표시하는 컴포넌트
- `FormButton`: 버튼 스타일과 동작을 통일한 컴포넌트

### 폼 로직 개선
- 이미지 업로드 로직을 폼 제출 시점으로 변경
- 비밀번호 변경 폼 상태 관리 개선
- 에러 처리 및 메시지 표시 방식 통일

### UI/UX 개선
- 프로필 페이지 레이아웃 최적화
- 반응형 디자인 개선
- 입력 필드와 버튼 스타일 통일
- 컴포넌트 간 여백 및 정렬 조정

## 테스트 항목
- [x] 프로필 정보 수정 기능
- [x] 프로필 이미지 업로드/삭제
- [x] 비밀번호 변경 기능
- [x] 반응형 레이아웃 (모바일/데스크톱)
- [x] 폼 유효성 검사 및 에러 메시지
- [x] 성공/실패 상태 표시

